### PR TITLE
Topic JSON fix (again)

### DIFF
--- a/backend/src/main/java/org/wcci/cardsagainststupidity/models/Topic.java
+++ b/backend/src/main/java/org/wcci/cardsagainststupidity/models/Topic.java
@@ -22,7 +22,7 @@ public class Topic {
     private Long id;
     private String title;
     @OneToMany(mappedBy = "topic")
-    @JsonIgnoreProperties("topic")
+    @JsonIgnoreProperties({"topic", "cards"})
     private Collection<Deck> decks = new ArrayList<>();
     
     public Topic() {


### PR DESCRIPTION
Included cards in JSON ignored properties of the collection of decks
in the Topic POJO (should now only show deck names)